### PR TITLE
Publish to npm on github release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+on:
+  release:
+    created: {}
+    
+jobs:
+  release-all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.5.0
+      - name: Setup Node
+        uses: actions/setup-node@v3.5.1
+      - name: Publish to npm
+        run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
         uses: actions/checkout@v2.5.0
       - name: Setup Node
         uses: actions/setup-node@v3.5.1
+        with: 
+          node-version: latest
+          registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
         run: yarn publish
         env:


### PR DESCRIPTION
this script publishes to npm when you create a github release. it requries a secret called `NPM_TOKEN` to be set for the repository with sufficient permissions to publish.